### PR TITLE
feat:adding game collection in strapi

### DIFF
--- a/src/api/game/content-types/game/schema.json
+++ b/src/api/game/content-types/game/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "games",
+  "info": {
+    "singularName": "game",
+    "pluralName": "games",
+    "displayName": "Game"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "steamId": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "image": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/src/api/game/controllers/game.ts
+++ b/src/api/game/controllers/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::game.game');

--- a/src/api/game/routes/game.ts
+++ b/src/api/game/routes/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::game.game');

--- a/src/api/game/services/game.ts
+++ b/src/api/game/services/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::game.game');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -506,6 +506,37 @@ export interface ApiCategoryCategory extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiGameGame extends Struct.CollectionTypeSchema {
+  collectionName: 'games';
+  info: {
+    displayName: 'Game';
+    pluralName: 'games';
+    singularName: 'game';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.RichText;
+    image: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios',
+      true
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::game.game'> &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    steamId: Schema.Attribute.String;
+    title: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
   collectionName: 'globals';
   info: {
@@ -1051,6 +1082,7 @@ declare module '@strapi/strapi' {
       'api::article.article': ApiArticleArticle;
       'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;
+      'api::game.game': ApiGameGame;
       'api::global.global': ApiGlobalGlobal;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;


### PR DESCRIPTION
# What's New

🎮 Introduced a Games collection in Strapi CMS

📌 Fields include:

title: Name of the game

steamId: Unique Steam identifier

image: Game cover or related media

description: Rich text support for game descriptions

🧩 This lays the foundation for managing and displaying game data dynamically in your frontend app
