### PR TITLE
feat: Account creation when user is created

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,34 @@ export default {
   /**
    * An asynchronous register function that runs before
    * your application is initialized.
-   *
-   * This gives you an opportunity to extend code.
    */
   register(/* { strapi }: { strapi: Core.Strapi } */) {},
 
   /**
    * An asynchronous bootstrap function that runs before
    * your application gets started.
-   *
-   * This gives you an opportunity to set up your data model,
-   * run jobs, or perform some special logic.
    */
-  bootstrap(/* { strapi }: { strapi: Core.Strapi } */) {},
+  async bootstrap({ strapi } /* : { strapi: Core.Strapi } */) {
+    strapi.db.lifecycles.subscribe({
+      models: ["plugin::users-permissions.user"],
+
+      async afterCreate(event) {
+        const { result } = event;
+
+        try {
+          await strapi.documents("api::account.account").create({
+            data: {
+              username: result.username,
+              user: result.id,
+              level: 1,
+              bio: "",
+            },
+            status: 'published',
+          });
+        } catch (error) {
+          console.error("Error creating account:", error);
+        }
+      },
+    });
+  },
 };


### PR DESCRIPTION
# What's New

- Added lifecycle hook on user creation to automatically create an associated Account entry.

- Account entries are now auto-published immediately after creation to avoid draft status.

- Improved consistency between User and Account data with seamless synchronization.

- Enhanced onboarding experience by ensuring accounts are live and accessible upon user registration.