### PR TITLE
Feat/ Steam API added to backend to retrieve user data and games

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ Feel free to check out the [Strapi GitHub repository](https://github.com/strapi/
 ---
 
 <sub>🤫 Psst! [Strapi is hiring](https://strapi.io/careers).</sub>
+
+
+![image](https://github.com/user-attachments/assets/a9597bcf-5383-4424-988c-65e3a5a2de43)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@strapi/strapi": "5.15.0",
     "fs-extra": "^10.0.0",
     "mime-types": "^2.1.27",
+    "node-fetch": "^3.3.2",
     "pg": "8.8.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/src/api/account/content-types/account/schema.json
+++ b/src/api/account/content-types/account/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "collectionType",
+  "collectionName": "accounts",
+  "info": {
+    "singularName": "account",
+    "pluralName": "accounts",
+    "displayName": "Account"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "username": {
+      "type": "string"
+    },
+    "bio": {
+      "type": "text"
+    },
+    "avatar": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "level": {
+      "type": "integer"
+    },
+    "experience": {
+      "type": "integer"
+    },
+    "user": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "account"
+    },
+    "joinedDate": {
+      "type": "date"
+    }
+  }
+}

--- a/src/api/account/controllers/account.ts
+++ b/src/api/account/controllers/account.ts
@@ -1,0 +1,7 @@
+/**
+ * account controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::account.account');

--- a/src/api/account/routes/account.ts
+++ b/src/api/account/routes/account.ts
@@ -1,0 +1,7 @@
+/**
+ * account router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::account.account');

--- a/src/api/account/services/account.ts
+++ b/src/api/account/services/account.ts
@@ -1,0 +1,7 @@
+/**
+ * account service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::account.account');

--- a/src/api/game/content-types/game/schema.json
+++ b/src/api/game/content-types/game/schema.json
@@ -1,0 +1,34 @@
+{
+  "kind": "collectionType",
+  "collectionName": "games",
+  "info": {
+    "singularName": "game",
+    "pluralName": "games",
+    "displayName": "Game"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "steamId": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "image": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    }
+  }
+}

--- a/src/api/game/controllers/game.ts
+++ b/src/api/game/controllers/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::game.game');

--- a/src/api/game/controllers/game.ts
+++ b/src/api/game/controllers/game.ts
@@ -2,6 +2,24 @@
  * game controller
  */
 
-import { factories } from '@strapi/strapi'
+import { factories } from "@strapi/strapi";
 
-export default factories.createCoreController('api::game.game');
+export default factories.createCoreController("api::game.game", ({ strapi }) => ({
+  async getSteamProfile(ctx) {
+    try {
+      const profile = await strapi.service("api::game.game").getSteamProfile();
+      ctx.send(profile);
+    } catch (error) {
+      ctx.throw(500, "Failed to fetch Steam profile");
+    }
+  },
+
+  async getSteamGames(ctx) {
+    try {
+      const games = await strapi.service("api::game.game").getSteamGames();
+      ctx.send(games);
+    } catch (error) {
+      ctx.throw(500, "Failed to fetch Steam games");
+    }
+  }
+}));

--- a/src/api/game/routes/custom.ts
+++ b/src/api/game/routes/custom.ts
@@ -1,0 +1,20 @@
+export default {
+  routes: [
+    {
+      method: 'GET',
+      path: '/game/steam-profile',
+      handler: 'game.getSteamProfile',
+      config: {
+        policies: [],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/game/steam-games',
+      handler: 'game.getSteamGames',
+      config: {
+        policies: [],
+      },
+    },
+  ],
+};

--- a/src/api/game/routes/game.ts
+++ b/src/api/game/routes/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::game.game');

--- a/src/api/game/services/game.ts
+++ b/src/api/game/services/game.ts
@@ -1,0 +1,7 @@
+/**
+ * game service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::game.game');

--- a/src/api/game/services/game.ts
+++ b/src/api/game/services/game.ts
@@ -2,6 +2,54 @@
  * game service
  */
 
-import { factories } from '@strapi/strapi';
+import { factories } from "@strapi/strapi";
+import fetch from "node-fetch";
+import game from "../controllers/game";
 
-export default factories.createCoreService('api::game.game');
+const steamApiKey = process.env.STEAM_API_KEY;
+const steamID = "76561198451045399"; // Replace with a real Steam ID
+
+type SteamPlayerSummaryResponse = {
+  response: {
+    players: Array<Record<string, any>>;
+  };
+};
+
+
+type SteamGamesOwned = {
+  response: {
+    games: Array<Record<string, any>>;
+  };
+};
+
+export default factories.createCoreService("api::game.game", ({ strapi }) => ({
+  async getSteamProfile() {
+    try {
+      const response = await fetch(
+        `https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=${steamApiKey}&steamids=${steamID}`
+      );
+
+      const data = (await response.json()) as SteamPlayerSummaryResponse;
+      return data.response.players[0] || null;
+    } catch (error) {
+      strapi.log.error("Failed to fetch Steam data:", error);
+      throw new Error("Steam API call failed");
+    }
+  },
+
+  async getSteamGames() {
+    try {
+      const response = await fetch(
+        `https://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=${steamApiKey}&steamid=${steamID}&include_appinfo=true&include_played_free_games=true&format=json`
+      );
+
+      const data = await response.json() as SteamGamesOwned;
+      const games = data.response.games || [];
+      games.sort((a, b) => b.playtime_forever - a.playtime_forever);
+      return games;
+    } catch (error) {
+      strapi.log.error("Failed to fetch Steam games:", error);
+      throw new Error("Steam API call failed");
+    }
+  },
+}));

--- a/src/api/progress/content-types/progress/schema.json
+++ b/src/api/progress/content-types/progress/schema.json
@@ -1,0 +1,32 @@
+{
+  "kind": "collectionType",
+  "collectionName": "progresses",
+  "info": {
+    "singularName": "progress",
+    "pluralName": "progresses",
+    "displayName": "Progress"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "playTime": {
+      "type": "integer"
+    },
+    "completed": {
+      "type": "boolean",
+      "default": false
+    },
+    "account": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::account.account"
+    },
+    "game": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::game.game"
+    }
+  }
+}

--- a/src/api/progress/controllers/progress.ts
+++ b/src/api/progress/controllers/progress.ts
@@ -1,0 +1,7 @@
+/**
+ * progress controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::progress.progress');

--- a/src/api/progress/routes/progress.ts
+++ b/src/api/progress/routes/progress.ts
@@ -1,0 +1,7 @@
+/**
+ * progress router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::progress.progress');

--- a/src/api/progress/services/progress.ts
+++ b/src/api/progress/services/progress.ts
@@ -1,0 +1,7 @@
+/**
+ * progress service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::progress.progress');

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -1,0 +1,76 @@
+{
+  "kind": "collectionType",
+  "collectionName": "up_users",
+  "info": {
+    "name": "user",
+    "description": "",
+    "singularName": "user",
+    "pluralName": "users",
+    "displayName": "User"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "username": {
+      "type": "string",
+      "minLength": 3,
+      "unique": true,
+      "configurable": false,
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "minLength": 6,
+      "configurable": false,
+      "required": true
+    },
+    "provider": {
+      "type": "string",
+      "configurable": false
+    },
+    "password": {
+      "type": "password",
+      "minLength": 6,
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "resetPasswordToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmed": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "blocked": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "role": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.role",
+      "inversedBy": "users",
+      "configurable": false
+    },
+    "account": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::account.account",
+      "mappedBy": "user"
+    }
+  }
+}

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -609,6 +609,37 @@ export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiProgressProgress extends Struct.CollectionTypeSchema {
+  collectionName: 'progresses';
+  info: {
+    displayName: 'Progress';
+    pluralName: 'progresses';
+    singularName: 'progress';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    account: Schema.Attribute.Relation<'oneToOne', 'api::account.account'>;
+    completed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    game: Schema.Attribute.Relation<'oneToOne', 'api::game.game'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::progress.progress'
+    > &
+      Schema.Attribute.Private;
+    playTime: Schema.Attribute.Integer;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface PluginContentReleasesRelease
   extends Struct.CollectionTypeSchema {
   collectionName: 'strapi_releases';
@@ -1125,6 +1156,7 @@ declare module '@strapi/strapi' {
       'api::category.category': ApiCategoryCategory;
       'api::game.game': ApiGameGame;
       'api::global.global': ApiGlobalGlobal;
+      'api::progress.progress': ApiProgressProgress;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -402,6 +402,46 @@ export interface ApiAboutAbout extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiAccountAccount extends Struct.CollectionTypeSchema {
+  collectionName: 'accounts';
+  info: {
+    displayName: 'Account';
+    pluralName: 'accounts';
+    singularName: 'account';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    avatar: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios',
+      true
+    >;
+    bio: Schema.Attribute.Text;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    experience: Schema.Attribute.Integer;
+    joinedDate: Schema.Attribute.Date;
+    level: Schema.Attribute.Integer;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::account.account'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    user: Schema.Attribute.Relation<
+      'oneToOne',
+      'plugin::users-permissions.user'
+    >;
+    username: Schema.Attribute.String;
+  };
+}
+
 export interface ApiArticleArticle extends Struct.CollectionTypeSchema {
   collectionName: 'articles';
   info: {
@@ -993,9 +1033,9 @@ export interface PluginUsersPermissionsUser
   };
   options: {
     draftAndPublish: false;
-    timestamps: true;
   };
   attributes: {
+    account: Schema.Attribute.Relation<'oneToOne', 'api::account.account'>;
     blocked: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;
     confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
@@ -1048,6 +1088,7 @@ declare module '@strapi/strapi' {
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
       'api::about.about': ApiAboutAbout;
+      'api::account.account': ApiAccountAccount;
       'api::article.article': ApiArticleArticle;
       'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -546,6 +546,37 @@ export interface ApiCategoryCategory extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiGameGame extends Struct.CollectionTypeSchema {
+  collectionName: 'games';
+  info: {
+    displayName: 'Game';
+    pluralName: 'games';
+    singularName: 'game';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.RichText;
+    image: Schema.Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios',
+      true
+    >;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::game.game'> &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    steamId: Schema.Attribute.String;
+    title: Schema.Attribute.String;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiGlobalGlobal extends Struct.SingleTypeSchema {
   collectionName: 'globals';
   info: {
@@ -1092,6 +1123,7 @@ declare module '@strapi/strapi' {
       'api::article.article': ApiArticleArticle;
       'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;
+      'api::game.game': ApiGameGame;
       'api::global.global': ApiGlobalGlobal;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4233,6 +4233,11 @@ custom-media-element@~1.4.3:
   resolved "https://registry.yarnpkg.com/custom-media-element/-/custom-media-element-1.4.3.tgz#aaa3a1ddb6b73a24ac49057414776e4485877880"
   integrity sha512-6DAQAC9VfpdUEc684Kr1Uvw+49vKUY3+hAQcBrqMNL577PeA8eM8YgpOmbySoTZ517EIqSVFrXH2nu8gqFJS4g==
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 date-fns-tz@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.1.tgz#0a9b2099031c0d74120b45de9fd23192e48ea495"
@@ -4957,6 +4962,14 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -5091,6 +5104,13 @@ form-data@^4.0.0:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 formidable@^2.0.1:
   version "2.1.5"
@@ -7153,6 +7173,20 @@ node-abort-controller@^3.0.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
+
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-machine-id@1.1.12:
   version "1.1.12"
@@ -9753,6 +9787,11 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webpack-bundle-analyzer@^4.10.1:
   version "4.10.2"


### PR DESCRIPTION
#What's New

- Integrated Steam API into Strapi backend to fetch user game data.

- Implemented GetOwnedGames endpoint to retrieve all owned games for a given Steam ID.

- Enabled include_appinfo and include_played_free_games flags to fetch full game metadata (e.g., name, icon, logo).

- Sorted owned games by playtime_forever in descending order to highlight most-played titles.

- Added a custom controller method getOwnedGames() to serve game data via Strapi API.

- Improved error handling for failed Steam API calls.